### PR TITLE
fix Waiting pcm is timeout bug

### DIFF
--- a/tts_fast/cosyvoice2_fast/llm.py
+++ b/tts_fast/cosyvoice2_fast/llm.py
@@ -108,20 +108,19 @@ class CosyVoice2LLMWrapper:
         ):
             yield output.outputs[0].token_ids
 
-    async def background_generate(self, *args, q: asyncio.Queue, **kwargs):
+    async def background_generate(self, *args, q: asyncio.Queue, main_loop, **kwargs):
         try:
             async for tokens in self.engine_generate_fn(*args, **kwargs):
-                q.put_nowait(tokens)
+                main_loop.call_soon_threadsafe(q.put_nowait, tokens)
         finally:
-            q.put_nowait(None)
+            main_loop.call_soon_threadsafe(q.put_nowait, None)
 
     async def call_engine_generation(self, *args, **kwargs):
         q = asyncio.Queue()
-        asyncio.run_coroutine_threadsafe(
-            self.background_generate(*args, **kwargs, q=q), self.loop
-        )
+        main_loop = asyncio.get_running_loop()
+        asyncio.run_coroutine_threadsafe(self.background_generate(*args, **kwargs, q=q, main_loop=main_loop), self.loop)
         while True:
-            tokens = q.get_nowait() if not q.empty() else await q.get()
+            tokens = await q.get()
             if tokens is None:
                 break
             yield tokens


### PR DESCRIPTION
"pcm is timeout" 出现的原因卡在：tts_fast/cosyvoice2_fast/llm.py的 inference_bistream 方法中，具体是在调用 self.call_engine_generation 时挂起。

原因分析：
  问题出在 call_engine_generation 和 background_generate 方法中的跨线程通信方式不安全。
   1. call_engine_generation 在主线程（Main Loop）中创建了一个 asyncio.Queue。
   2. 它使用 asyncio.run_coroutine_threadsafe 将 background_generate 调度到另一个专用线程 (self.loop) 上运行。
   3. background_generate 试图直接调用 q.put_nowait(tokens) 向队列放入数据。

核心问题：
asyncio.Queue 不是线程安全的。从另一个线程直接调用 q.put_nowait（它是非阻塞的，且直接操作队列内部状态）会导致竞态条件，或者无法正确唤醒主线程中等待 await q.get() 的协程，从而导致死锁或挂起。


简单来说，之前的写法属于 “未定义行为”（Undefined Behavior）。在某些特定情况下（特定的 Python 版本、操作系统、CPU 负载、uvloop版本），它可能“看起来”是正常的，但这纯属“巧合”或“运气”。

有时候可以work，有时不行，主要有以下几个技术原因：

1. “轮询”巧合掩盖了信号丢失

  请注意代码中有这一句： tokens = q.get_nowait() if not q.empty() else await q.get()
  这里有一个 if not q.empty() 的检查。
   * 幸运的情况：如果后台线程生成数据的速度非常快，或者 Python 的 GIL（全局解释器锁）调度恰好让主线程在检查 q.empty() 时看到了数据，主线程就会直接执行 get_nowait() 取走数据。这时候，主线程根本没有进入 await q.get() 的挂起状态，也就无需等待“唤醒信号”。只要一直走这条路，程序就能跑通。
   * 卡住的情况（你遇到的）：一旦队列为空（数据生成慢了，或被消费完了），主线程执行 await q.get() 并进入休眠等待。此时，后台线程调用 q.put_nowait() 放入新数据。关键点在于： 标准的 asyncio.Queue 不是线程安全的，它在非主线程被调用时，无法正确触发底层的事件循环唤醒机制（wakeup file descriptor/socket）。结果就是：数据虽然进了队列，但主线程还在“沉睡”，没人叫醒它，程序就永远挂起了。

2. `asyncio.Queue` 不是线程安全的

  Python 的 asyncio.Queue 专门设计用于单线程内的协程通信。它的内部实现（如 collections.deque 的操作和 Future 的设置）并没有加线程锁。
   * 虽然 Python 的 GIL 在一定程度上保护了内存不崩溃，但在多线程同时读写队列内部结构时，仍然可能导致状态不一致。
   * 之所以有人能运行，是因为 GIL 碰巧序列化了这两个线程的操作，但这不可靠。

3. 环境差异 (uvloop vs asyncio)

  不同的事件循环实现（如 uvloop 和原生 asyncio）对跨线程操作的容忍度不同。
   * 有些旧版本的实现可能在某些条件下能容忍这种不规范操作。
   * 但在现代高并发环境下，或者特定的库版本（如你环境中的配置）下，这种竞态条件（Race Condition）就会暴露出来，导致死锁。

总结：
  之前的写法是在“走钢丝”。之所以卡住，是因为程序运行到了“队列为空，需要等待”的时刻，而跨线程的唤醒机制失效了。修复后的写法通过 call_soon_threadsafe 显式地告诉主线程的事件循环：“嘿，醒醒，有任务要在你的线程里执行”。